### PR TITLE
Allow compilation in MacOS

### DIFF
--- a/iff2gif.cpp
+++ b/iff2gif.cpp
@@ -21,7 +21,7 @@
 #include <fstream>
 #include "iff2gif.h"
 
-#ifdef __linux__
+#if defined(__linux__) or defined(__MACH__)
 #include <cstring>
 #include <climits>
 #include <algorithm>
@@ -195,7 +195,7 @@ int _tmain(int argc, _TCHAR* argv[])
 	return 0;
 }
 
-#ifdef __linux__
+#if defined(__linux__) or defined(__MACH__)
 int main(int argc, char *argv[])
 {
 	return _tmain(argc, argv);

--- a/iffread.cpp
+++ b/iffread.cpp
@@ -22,7 +22,7 @@
 #include <iostream>
 #include <assert.h>
 #include <string.h>
-#include <malloc.h>
+#include <stdlib.h>
 #include <math.h>
 
 #include "iff2gif.h"


### PR DESCRIPTION
## Build target
arm64-apple-darwin24.6.0

## Build environment
cmake version 4.2.0
GNU Make 3.81
Apple clang version 17.0.0

## Build output

```
foxracing@Mac iff2gif % cmake .
-- The C compiler identification is AppleClang 17.0.0.17000013
-- The CXX compiler identification is AppleClang 17.0.0.17000013
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: /usr/bin/cc - skipped
-- Detecting C compile features
-- Detecting C compile features - done
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: /usr/bin/c++ - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Configuring done (0.5s)
-- Generating done (0.0s)
-- Build files have been written to: /Users/foxracing/iff/iff2gif

foxracing@Mac iff2gif % make
[  8%] Building CXX object CMakeFiles/iff2gif.dir/iff2gif.cpp.o
[ 16%] Building CXX object CMakeFiles/iff2gif.dir/gifwrite.cpp.o
[ 25%] Building CXX object CMakeFiles/iff2gif.dir/iffread.cpp.o
[ 33%] Building CXX object CMakeFiles/iff2gif.dir/chunky.cpp.o
[ 41%] Building CXX object CMakeFiles/iff2gif.dir/planar.cpp.o
[ 50%] Building CXX object CMakeFiles/iff2gif.dir/ppunpack.cpp.o
[ 58%] Building CXX object CMakeFiles/iff2gif.dir/rotate.cpp.o
[ 66%] Building CXX object CMakeFiles/iff2gif.dir/mediancut.cpp.o
[ 75%] Building CXX object CMakeFiles/iff2gif.dir/neuquant.cpp.o
[ 83%] Building CXX object CMakeFiles/iff2gif.dir/quantizer.cpp.o
[ 91%] Building CXX object CMakeFiles/iff2gif.dir/palette.cpp.o
[100%] Linking CXX executable iff2gif
[100%] Built target iff2gif
```

## Testing
Converted a sample anim. It worked.
